### PR TITLE
Feature: Improve prop types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add improved prop types
+- Add "withastro" keyword
+
 ## [1.1.0] - 2022-10-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The `Emoji` component consumes two props: `symbol` and `label`. Every other prop
 
 ### Forbidden properties
 
-The following properties are managed internally, and will throw an error if passes as props to `Emoji`:
+The following properties are managed internally, and therefore ignored if passes as props to `Emoji`:
 
 - `aria-hidden`
 - `aria-label`

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 Emojis can add a light playfulness to your project but require some specific formatting in order to ensure they are accessible for all users. `astro-emoji`'s reusable `Emoji` component helps you do that quickly and painlessly.
 
-This component was ported to Astro from [`svelte-emoji`](https://npm.im/svelte-emoji).
-
 ## Installation
 
 Add `astro-emoji` to your project:
@@ -24,7 +22,7 @@ yarn add astro-emoji
 
 Import the default `Emoji` from `astro-emoji` and add it to your code:
 
-```jsx
+```astro
 ---
 import Emoji from 'astro-emoji':
 ---
@@ -46,14 +44,25 @@ The resulting markup for that component signature will be:
 
 `Emoji`s with no `label` prop are rendered with `aria-hidden="true"`:
 
-```html
+```astro
 <Emoji symbol="🤐" />
+<!-- Renders -->
 <span aria-hidden="true" role="img">🤐</span>
 ```
 
 ## Emoji component
 
 The `Emoji` component consumes two props: `symbol` and `label`. Every other prop is spread to the top-level `<span>` element.
+
+### Forbidden properties
+
+The following properties are managed internally, and will throw an error if passes as props to `Emoji`:
+
+- `aria-hidden`
+- `aria-label`
+- `role`
+
+The main benefit of using `astro-emoji` is that you don't need to worry about setting these HTML attributes correctly yourself.
 
 ## License
 

--- a/src/Emoji.astro
+++ b/src/Emoji.astro
@@ -16,7 +16,10 @@ const forbiddenAttributes = ["aria-hidden", "aria-label", "role"];
 
 forbiddenAttributes.forEach((attr) => {
   if (rest.hasOwnProperty(attr)) {
-    throw new Error(`The \`${attr}\` attribute is handled internally`);
+    console.warn(
+      `\`Emoji\` handles the \`${attr}\` attribute internally. Ignoring passed value \`${rest[attr]}\``
+    );
+    delete rest[attr];
   }
 });
 ---

--- a/src/Emoji.astro
+++ b/src/Emoji.astro
@@ -1,9 +1,24 @@
 ---
-export interface Props {
+import { HTMLAttributes } from "astro/types";
+
+type Attributes = Omit<
+  HTMLAttributes<"span">,
+  "aria-hidden" | "aria-label" | "role"
+>;
+
+export interface Props extends Attributes {
   label?: string;
   symbol: string;
 }
+
 const { label = null, symbol, ...rest } = Astro.props;
+const forbiddenAttributes = ["aria-hidden", "aria-label", "role"];
+
+forbiddenAttributes.forEach((attr) => {
+  if (rest.hasOwnProperty(attr)) {
+    throw new Error(`The \`${attr}\` attribute is handled internally`);
+  }
+});
 ---
 
 <span aria-hidden={label ? null : true} aria-label={label} role="img" {...rest}>

--- a/tests/Emoji.mjs
+++ b/tests/Emoji.mjs
@@ -41,4 +41,36 @@ test("When label and symbol are provided, renders labelled emoji", async () => {
   assert.not.match(html, "aria-hidden");
 });
 
+test("Forwards props to attributes", async () => {
+  const label = "Test tube";
+  const symbol = "🧪";
+  const html = await getHTML({
+    label,
+    symbol,
+    class: "test",
+    id: "test",
+    "data-test": "test",
+  });
+
+  assert.match(html, 'class="test"');
+  assert.match(html, 'id="test"');
+  assert.match(html, 'data-test="test"');
+});
+
+test("Ignores forbidden attributes", async () => {
+  const label = "Test tube";
+  const symbol = "🧪";
+  const html = await getHTML({
+    label,
+    symbol,
+    "aria-hidden": "test",
+    "aria-label": "test",
+    role: "test",
+  });
+
+  assert.not.match(html, 'aria-hidden="test"');
+  assert.not.match(html, 'aria-label="test"');
+  assert.not.match(html, 'role="test"');
+});
+
 test.run();

--- a/tests/Props.test.astro
+++ b/tests/Props.test.astro
@@ -5,6 +5,8 @@ import Emoji from '../src/Emoji.astro'
 <!-- Pass --><Emoji symbol="🧪" />
 <!-- Pass --><Emoji label="Science!" symbol="🧪" />
 
-
 <!-- Fail --><Emoji />
 <!-- Fail --><Emoji label="Blank" />
+<!-- Fail --><Emoji symbol="🧪" aria-label="anything" />
+<!-- Fail --><Emoji symbol="🧪" aria-hidden="anything" />
+<!-- Fail --><Emoji symbol="🧪" role="anything" />

--- a/tests/Props.test.astro
+++ b/tests/Props.test.astro
@@ -1,12 +1,15 @@
 ---
-import Emoji from '../src/Emoji.astro'
+import Emoji from "../src/Emoji.astro";
 ---
 
-<!-- Pass --><Emoji symbol="🧪" />
-<!-- Pass --><Emoji label="Science!" symbol="🧪" />
+<!-- Pass -->
+<Emoji symbol="🧪" />
 
-<!-- Fail --><Emoji />
-<!-- Fail --><Emoji label="Blank" />
-<!-- Fail --><Emoji symbol="🧪" aria-label="anything" />
-<!-- Fail --><Emoji symbol="🧪" aria-hidden="anything" />
-<!-- Fail --><Emoji symbol="🧪" role="anything" />
+<!-- Pass -->
+<Emoji label="Science!" symbol="🧪" />
+
+<!-- Fail: Property 'symbol' is missing -->
+<Emoji />
+
+<!-- Fail: Property 'symbol' is missing -->
+<Emoji label="Blank" />


### PR DESCRIPTION
This PR does two things:
1. It extends the exported `Props` type from `HTMLAttributes<'span'>`, and
2. Ignores `aria-hidden`, `aria-label`, and `role` props with a warning.

~~This is technically a breaking change since we now throw when a forbidden attribute is passed.~~ After a refactor, this is not a minor change.